### PR TITLE
WebScoket再接続できるように再度修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mecab-async": "0.1.2",
     "misskey-reversi": "0.0.5",
     "promise-retry": "1.1.1",
-    "reconnecting-websocket": "3.2.2",
+    "reconnecting-websocket": "4.0.0-rc5",
     "request": "2.87.0",
     "request-promise-native": "1.0.5",
     "seedrandom": "2.4.3",

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -70,7 +70,7 @@ export default class 藍 {
 
 		//#region Home stream
 		this.connection = new ReconnectingWebSocket(`${config.wsUrl}/?i=${config.i}`, [], {
-			constructor: WebSocket
+			WebSocket: WebSocket
 		});
 
 		this.connection.addEventListener('open', () => {
@@ -79,6 +79,7 @@ export default class 藍 {
 
 		this.connection.addEventListener('close', () => {
 			console.log('home stream closed');
+			this.connection._shouldReconnect && this.connection._connect()
 		});
 
 		this.connection.addEventListener('message', message => {
@@ -90,7 +91,7 @@ export default class 藍 {
 
 		//#region Local timeline stream
 		this.localTimelineConnection = new ReconnectingWebSocket(`${config.wsUrl}/local-timeline?i=${config.i}`, [], {
-			constructor: WebSocket
+			WebSocket: WebSocket
 		});
 
 		this.localTimelineConnection.addEventListener('open', () => {
@@ -99,6 +100,7 @@ export default class 藍 {
 
 		this.localTimelineConnection.addEventListener('close', () => {
 			console.log('local-timeline stream closed');
+			this.localTimelineConnection._shouldReconnect && this.localTimelineConnection._connect()
 		});
 
 		this.localTimelineConnection.addEventListener('message', message => {

--- a/src/modules/reversi/index.ts
+++ b/src/modules/reversi/index.ts
@@ -23,7 +23,7 @@ export default class ReversiModule implements IModule {
 		this.ai = ai;
 
 		this.reversiConnection = new ReconnectingWebSocket(`${config.wsUrl}/games/reversi?i=${config.i}`, [], {
-			constructor: WebSocket
+			WebSocket: WebSocket
 		});
 
 		this.reversiConnection.addEventListener('open', () => {
@@ -32,6 +32,7 @@ export default class ReversiModule implements IModule {
 
 		this.reversiConnection.addEventListener('close', () => {
 			console.log('reversi stream closed');
+			this.reversiConnection._shouldReconnect && this.reversiConnection._connect()
 		});
 
 		this.reversiConnection.addEventListener('message', message => {
@@ -97,7 +98,7 @@ export default class ReversiModule implements IModule {
 	private onReversiGameStart = (game: any) => {
 		// ゲームストリームに接続
 		const gw = new ReconnectingWebSocket(`${config.wsUrl}/games/reversi-game?i=${config.i}&game=${game.id}`, [], {
-			constructor: WebSocket
+			WebSocket: WebSocket
 		});
 
 		function send(msg) {
@@ -189,6 +190,7 @@ export default class ReversiModule implements IModule {
 
 		gw.addEventListener('close', () => {
 			console.log('reversi game stream closed');
+			gw._shouldReconnect && gw._connect()
 		});
 	}
 

--- a/src/modules/server/index.ts
+++ b/src/modules/server/index.ts
@@ -23,7 +23,7 @@ export default class ServerModule implements IModule {
 		this.ai = ai;
 
 		this.connection = new ReconnectingWebSocket(`${config.wsUrl}/server-stats`, [], {
-			constructor: WebSocket
+			WebSocket: WebSocket
 		});
 
 		this.connection.addEventListener('open', () => {
@@ -32,6 +32,7 @@ export default class ServerModule implements IModule {
 
 		this.connection.addEventListener('close', () => {
 			console.log('server-stats stream closed');
+			this.connection._shouldReconnect && this.connection._connect()
 		});
 
 		this.connection.addEventListener('message', message => {


### PR DESCRIPTION
#11 #12 で対応したものでも
途中で切断された後の再接続がエラーで終了してしまうことの修正

#11 にある
3.2.2 だと起きて、4.0.0-rc5で`_shouldReconnect && rws._connect()`する方法だと大丈夫みたいなので
そちらにしています。

切断後、502 と TCP Reset を返されるパターンでリトライして再接続できることを確認してます。