### PR TITLE
サーバー監視が動いてないのを修正

### DIFF
--- a/src/modules/server/index.ts
+++ b/src/modules/server/index.ts
@@ -50,7 +50,7 @@ export default class extends Module {
 
 	@autobind
 	private async onStats(stats: any) {
-		this.recentStat = stats.body;
+		this.recentStat = stats;
 	}
 
 	@autobind


### PR DESCRIPTION
v10以降 (v11も) 共にサーバー監視で常に0で集計し続けてるのを修正

そもそも #18 で undefined が流れてきてエラーになる時点でおかしかった

`body`は以下で指定済みなので不要
https://github.com/syuilo/ai/blob/56a5718cbd1aacd934905342d5368a162631cb93/src/stream.ts#L118-L121