### PR TITLE
MeCabに外部ライブラリを使わないようになど

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "canvas": "2.6.1",
     "chalk": "4.1.0",
     "lokijs": "1.5.11",
-    "mecab-async": "0.1.2",
+    "memory-streams": "0.1.3",
     "misskey-reversi": "0.0.5",
     "promise-retry": "2.0.1",
     "random-seed": "0.3.0",

--- a/src/modules/keyword/mecab.ts
+++ b/src/modules/keyword/mecab.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'child_process';
+import * as util from 'util';
+import * as stream from 'stream';
+import * as memoryStreams from 'memory-streams';
+import { EOL } from 'os';
+
+const pipeline = util.promisify(stream.pipeline);
+
+/**
+ * Run MeCab
+ * @param text Text to analyze
+ * @param mecab mecab bin
+ * @param dic mecab dictionaly path
+ */
+export async function mecab(text: string, mecab = 'mecab', dic?: string): Promise<string[][]> {
+	const args: string[] = [];
+	if (dic) args.push('-d', dic);
+
+	const lines = await cmd(mecab, args, `${text.replace(/[\n\s\t]/g, ' ')}\n`);
+
+	const results: string[][] = [];
+
+	for (const line of lines) {
+		if (line === 'EOS') break;
+		const [word, value = ''] = line.split('\t');
+		const array = value.split(',');
+		array.unshift(word);
+		results.push(array);
+	}
+
+	return results;
+}
+
+export async function cmd(command: string, args: string[], stdin: string): Promise<string[]> {
+	const mecab = spawn(command, args);
+
+	const writable = new memoryStreams.WritableStream();
+
+	mecab.stdin.write(stdin);
+	mecab.stdin.end();
+
+	await pipeline(mecab.stdout, writable);
+
+	return writable.toString().split(EOL);
+}


### PR DESCRIPTION
Fix #63 シェルのechoコマンドでパイプする外部ライブラリをやめて、NodeからSTDINに投入するように。
Fix #38 キーワードがマッチしないときにUnhandledPromiseRejectionが出るのを修正
Promiseで並列で外部コマンドを起動しないように