### PR TITLE
Dockerで動かせるようにする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+config.json
+font.ttf

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 config.json
 font.ttf
+data/memory.json
+ai.*
+*.md
+Dockerfile
+docker-compose.yml
+
+node_modules/
+.vscode/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 config.json
 font.ttf
-data/memory.json
 ai.*
 *.md
+*.png
 Dockerfile
 docker-compose.yml
+LICENSE
 
 node_modules/
+test/
+data/
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+
+FROM node:lts-bullseye
+RUN apt-get update && apt-get install -y tini
+
+COPY . /ai
+
+WORKDIR /ai
+RUN npm install && npm run build
+
+# install mecab and neologd
+RUN apt-get update \
+  && apt-get install mecab libmecab-dev mecab-ipadic-utf8 make curl xz-utils file sudo --no-install-recommends -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt-get/lists/* \
+  && cd /opt \
+  && git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git \
+  && cd /opt/mecab-ipadic-neologd \
+  && ./bin/install-mecab-ipadic-neologd -n -y \
+  && rm -rf /opt/mecab-ipadic-neologd \
+  && echo "dicdir = /usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/" > /etc/mecabrc \
+  && apt-get purge git make curl xz-utils file -y
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM node:lts-bullseye
+
 RUN apt-get update && apt-get install -y tini
 
-COPY . /ai
+ARG enable_mecab=1
 
-WORKDIR /ai
-RUN npm install && npm run build
-
-# install mecab and neologd
-RUN apt-get update \
+RUN if [ $enable_mecab -ne 0 ]; then apt-get update \
   && apt-get install mecab libmecab-dev mecab-ipadic-utf8 make curl xz-utils file sudo --no-install-recommends -y \
   && apt-get clean \
   && rm -rf /var/lib/apt-get/lists/* \
@@ -17,7 +14,12 @@ RUN apt-get update \
   && ./bin/install-mecab-ipadic-neologd -n -y \
   && rm -rf /opt/mecab-ipadic-neologd \
   && echo "dicdir = /usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/" > /etc/mecabrc \
-  && apt-get purge git make curl xz-utils file -y
+  && apt-get purge git make curl xz-utils file -y; fi
+
+COPY . /ai
+
+WORKDIR /ai
+RUN npm install && npm run build
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:lts-bullseye
 RUN apt-get update && apt-get install -y tini
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,33 @@ Misskey用の日本語Botです。
 	"reversiEnabled": "藍とリバーシで対局できる機能を有効にする場合は true を入れる (無効にする場合は false)",
 	"serverMonitoring": "サーバー監視の機能を有効にする場合は true を入れる (無効にする場合は false)",
 	"mecab": "MeCab のインストールパス (ソースからインストールした場合、大体は /usr/local/bin/mecab)",
-	"mecabDic": "MeCab の辞書ファイルパス (オプション)"
+	"mecabDic": "MeCab の辞書ファイルパス (オプション)",
+	"memoryPath": "memory.jsonの保存先（オプション、デフォルトは'.'（レポジトリのルートです））"
 }
 ```
 `npm install` して `npm run build` して `npm start` すれば起動できます
+
+## Dockerで動かす
+まず適当なディレクトリに `git clone` します。
+次にそのディレクトリに `config.json` を作成します。中身は次のようにします:
+（MeCabの設定、memoryPathについては触らないでください）
+``` json
+{
+	"host": "https:// + あなたのインスタンスのURL (末尾の / は除く)",
+	"i": "藍として動かしたいアカウントのアクセストークン",
+	"master": "管理者のユーザー名(オプション)",
+	"notingEnabled": "ランダムにノートを投稿する機能を無効にする場合は false を入れる",
+	"keywordEnabled": "キーワードを覚える機能 (MeCab が必要) を有効にする場合は true を入れる (無効にする場合は false)",
+	"chartEnabled": "チャート機能を無効化する場合は false を入れてください",
+	"reversiEnabled": "藍とリバーシで対局できる機能を有効にする場合は true を入れる (無効にする場合は false)",
+	"serverMonitoring": "サーバー監視の機能を有効にする場合は true を入れる (無効にする場合は false)",
+	"mecab": "/usr/bin/mecab",
+	"mecabDic": "/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/",
+	"memoryPath": "data"
+}
+```
+`docker-compose build` して `docker-compose up` すれば起動できます。
+`docker-compose.yml` の `enable_mecab` を `0` にすると、MeCabをインストールしないようにもできます。（メモリが少ない環境など）
 
 ## フォント
 一部の機能にはフォントが必要です。藍にはフォントは同梱されていないので、ご自身でフォントをインストールディレクトリに`font.ttf`という名前で設置してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - './config.json:/ai/config.json:ro'
+      - './font.ttf:/ai/font.ttf:ro'
+      - './data:/ai/data'
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: '3'
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        - enable_mecab=1
     volumes:
       - './config.json:/ai/config.json:ro'
       - './font.ttf:/ai/font.ttf:ro'

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -81,7 +81,12 @@ export default class 藍 {
 		this.account = account;
 		this.modules = modules;
 
-		const file = process.env.NODE_ENV === 'test' ? 'data/test.memory.json' : 'data/memory.json';
+		let memoryPath = './';
+		if (config.memoryPath)
+		{
+			memoryPath = config.memoryPath;
+		}
+		const file = process.env.NODE_ENV === 'test' ? `${memoryPath}/test.memory.json` : `${memoryPath}/memory.json`;
 
 		this.log(`Lodaing the memory from ${file}...`);
 

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -81,7 +81,7 @@ export default class 藍 {
 		this.account = account;
 		this.modules = modules;
 
-		const file = process.env.NODE_ENV === 'test' ? 'test.memory.json' : 'memory.json';
+		const file = process.env.NODE_ENV === 'test' ? 'data/test.memory.json' : 'data/memory.json';
 
 		this.log(`Lodaing the memory from ${file}...`);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ type Config = {
 	serverMonitoring: boolean;
 	mecab?: string;
 	mecabDic?: string;
+	memoryPath?: string;
 };
 
 const config = require('../config.json');


### PR DESCRIPTION
Dockerで動かせるようにDockerfileとdocker-compose.ymlを書きました。

memory.jsonの永続化をするにあたって、レポジトリのルートにファイルがあると少し問題があったので、config.jsonから場所を指定できるようにしています。（指定無しの場合はこれまでどおりの挙動です。）