### PR TITLE
最近サーバー監視が動かないのを修正

### DIFF
--- a/src/modules/server/index.ts
+++ b/src/modules/server/index.ts
@@ -39,7 +39,7 @@ export default class extends Module {
 	private check() {
 		const average = (arr) => arr.reduce((a, b) => a + b) / arr.length;
 
-		const cpuPercentages = this.statsLogs.map(s => s && s.cpu_usage * 100 || 0);
+		const cpuPercentages = this.statsLogs.map(s => s && (s.cpu_usage || s.cpu) * 100 || 0);
 		const cpuPercentage = average(cpuPercentages);
 		if (cpuPercentage >= 70) {
 			this.warn();


### PR DESCRIPTION
Fix #87
どのバージョンから動かなくなったのは忘れたけど、とりあえずこれで動いたはず。