### PR TITLE
リマインド機能の改善

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -34,6 +34,10 @@ export default class Message {
 		return this.messageOrNote.renoteId;
 	}
 
+	public get visibility(): string {
+		return this.messageOrNote.visibility;
+	}
+
 	/**
 	 * メンション部分を除いたテキスト本文
 	 */

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -59,9 +59,12 @@ export default class extends Module {
 		const separatorIndex = text.indexOf(' ') > -1 ? text.indexOf(' ') : text.indexOf('\n');
 		const thing = text.substr(separatorIndex + 1).trim();
 
-		if (thing === '' && msg.quoteId == null) {
+		if (thing === '' && msg.quoteId == null || msg.visibility === 'followers') {
 			msg.reply(serifs.reminder.invalid);
-			return true;
+			return {
+				reaction: '🆖',
+				immediate: true,
+			};
 		}
 
 		const remind = this.reminds.insertOne({

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -157,7 +157,7 @@ export default class extends Module {
 				});
 			} catch (err) {
 				// renote対象が消されていたらリマインダー解除
-				if (err.statusCode === 400 && err.error.error.message === 'No such renote target.') {
+				if (err.statusCode === 400) {
 					this.unsubscribeReply(remind.thing == null && remind.quoteId ? remind.quoteId : remind.id);
 					this.reminds.remove(remind);
 					return;

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -123,7 +123,7 @@ export default class extends Module {
 			msg.reply(done ? getSerif(serifs.reminder.done(msg.friend.name)) : serifs.reminder.cancel);
 			return;
 		} else if (isOneself === false) {
-			msg.reply("イタズラはめっですよ！");
+			msg.reply(serifs.reminder.doneFromInvalidUser);
 			return;
 		} else {
 			if (msg.isDm) this.unsubscribeReply(key);

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -115,11 +115,15 @@ export default class extends Module {
 
 		const done = msg.includes(['done', 'やった', 'やりました', 'はい']);
 		const cancel = msg.includes(['やめる', 'やめた', 'キャンセル']);
+		const isOneself = msg.userId === remind.userId;
 
-		if (done || cancel) {
+		if ((done || cancel) && isOneself) {
 			this.unsubscribeReply(key);
 			this.reminds.remove(remind);
 			msg.reply(done ? getSerif(serifs.reminder.done(msg.friend.name)) : serifs.reminder.cancel);
+			return;
+		} else if (isOneself === false) {
+			msg.reply("イタズラはめっですよ！");
 			return;
 		} else {
 			if (msg.isDm) this.unsubscribeReply(key);

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -149,7 +149,12 @@ export default class extends Module {
 					text: acct(friend.doc.user) + ' ' + serifs.reminder.notify(friend.name)
 				});
 			} catch (err) {
-				// TODO: renote対象が消されていたらリマインダー解除
+				// renote対象が消されていたらリマインダー解除
+				if (err.statusCode === 400 && err.error.error.message === 'No such renote target.') {
+					this.unsubscribeReply(remind.thing == null && remind.quoteId ? remind.quoteId : remind.id);
+					this.reminds.remove(remind);
+					return;
+				}
 				return;
 			}
 		}

--- a/src/serifs.ts
+++ b/src/serifs.ts
@@ -339,6 +339,8 @@ export default {
 	reminder: {
 		invalid: 'うーん...？',
 
+		doneFromInvalidUser: 'イタズラはめっですよ！',
+
 		reminds: 'やること一覧です！',
 
 		notify: (name) => name ? `${name}、これやりましたか？` : `これやりましたか？`,


### PR DESCRIPTION
# これは何
タイトルの通り。  
大きく3つの変更点があります。

## renote対象が消されていた場合にリマインダー解除を行う機能
#89 に関係しそう。  
「やった」「やめる」でリマインダー解除する場所と同じように書きました。
### 何が変わるの
リマインダーで、todoしてるノートが消されたら自動的にリマインドも解除する。

## リマインド対象のノートのvisibilityがfollowersのときにtodoを受け付けないようにした
todoをお願いしたノートのvisibilityが、followersとなっていた時に🆗とはなる。が、引用RNができなくてただ覚えているだけになっているので、それだったら最初から受け付けないようにすればいいんじゃない？となり書きました。

### 何が変わるの
- `msg.visibility`で公開範囲が取れるようになる
- リマインダーで、todoしてるノートのvisibilityが、followersだったら受け付けなくなる
- 受け付けられなかったときにNGのリアクションを返すようになる


## #70 他人のリマインダーを操作できるバグの修正
「やった」発言をしたユーザーidと、リマインド登録したユーザーidを比較し、一致しなければ画像の一番下のように返すように変更し、リマインダー解除しないようにした
![画像](https://misskey.na2na.dev/media/media/87c85e7f-aa79-412c-9d75-1ed4452f74e3.png)