### PR TITLE
npm依存パッケージcanvasのバージョン変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@types/uuid": "8.3.1",
 		"@types/ws": "7.4.6",
 		"autobind-decorator": "2.4.0",
-		"canvas": "2.8.0",
+		"canvas": "2.10.2",
 		"chalk": "4.1.1",
 		"lokijs": "1.5.12",
 		"memory-streams": "0.1.3",


### PR DESCRIPTION
canvasのパッケージが新規でインストールできなくなっているので更新しました。(**動作部分の詳しいコードまでは見ていないので、不適切でしたらそのままcloseしてください。**)

具体的には、現在新規でインストールしようとすると
```
npm ERR! node-pre-gyp http GET https://github.com/Automattic/node-canvas/releases/download/v2.8.0/canvas-v2.8.0-node-v108-linux-glibc-x64.tar.gz
npm ERR! node-pre-gyp ERR! install response status 404 Not Found on https://github.com/Automattic/node-canvas/releases/download/v2.8.0/canvas-v2.8.0-node-v108-linux-glibc-x64.tar.gz 
```
というエラーが出てbuildがコケてしまいます。これはnode-v108の部分に対応したものがcanvas v2.8.0に存在しないことに起因しており、これをv2.10.2まで上げるとnode-v108に対応するようになります。実際、v2.10.2に書き換えることで無事にbuildを通すことができるようになりました。