### PR TITLE
DockerのM1 Mac対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         - enable_mecab=1
+    platform: linux/amd64
     volumes:
       - './config.json:/ai/config.json:ro'
       - './font.ttf:/ai/font.ttf:ro'


### PR DESCRIPTION
M1 Mac (ARM64環境) 上でも動作するように、Dockerイメージのplatformを `linux/amd64` にします。