### PR TITLE
keywordEnabled=trueでMeCabがインストールされていない場合は起動前に異常終了する

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"_v": "1.5.0",
 	"main": "./built/index.js",
 	"scripts": {
-		"start": "node ./built",
+		"start": "./start.sh",
 		"build": "tsc",
 		"test": "jest"
 	},

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if (! which mecab) && (grep keywordEnabled config.json | grep -q true); then
+if (grep keywordEnabled config.json | grep -q true) && (! which mecab); then
   echo "You must install MeCab if keywordEnabled is true."
   exit 1
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ ! -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
+if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
   echo "You must install MeCab and mecab-ipadic-neologd if keywordEnabled is true."
   exit 1
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
+if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ ! -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
   echo "You must install MeCab and mecab-ipadic-neologd if keywordEnabled is true."
   exit 1
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if (! which mecab) && (grep keywordEnabled config.json | grep -q true); then
+  echo "You must install MeCab if keywordEnabled is true."
+  exit 1
+fi
+
+node ./built

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if (grep keywordEnabled config.json | grep -q true) && (! which mecab); then
-  echo "You must install MeCab if keywordEnabled is true."
+if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
+  echo "You must install MeCab and mecab-ipadic-neologd if keywordEnabled is true."
   exit 1
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if (grep keywordEnabled config.json | grep -q true) && (! which mecab) && [ -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
-  echo "You must install MeCab and mecab-ipadic-neologd if keywordEnabled is true."
+if (grep keywordEnabled config.json | grep -q true) && (! which mecab); then
+  echo "You must install MeCab if keywordEnabled is true."
   exit 1
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
-if (grep keywordEnabled config.json | grep -q true) && (! which mecab); then
-  echo "You must install MeCab if keywordEnabled is true."
-  exit 1
+if grep keywordEnabled config.json | grep -q true; then
+  if ! which mecab; then
+    echo "You must install MeCab if keywordEnabled is true."
+    exit 1
+  fi
+
+  if [ ! -e '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]; then
+    echo "You must install mecab-ipadic-neologd if keywordEnabled is true."
+    exit 1
+  fi
 fi
 
 node ./built


### PR DESCRIPTION
Fix https://github.com/syuilo/ai/issues/109

```
ai-app-1  | node:events:491
ai-app-1  |       throw er; // Unhandled 'error' event
ai-app-1  |       ^
ai-app-1  | 
ai-app-1  | Error: spawn /usr/bin/mecab ENOENT
ai-app-1  |     at ChildProcess._handle.onexit (node:internal/child_process:283:19)
ai-app-1  |     at onErrorNT (node:internal/child_process:476:16)
ai-app-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
ai-app-1  | Emitted 'error' event on ChildProcess instance at:
ai-app-1  |     at ChildProcess._handle.onexit (node:internal/child_process:289:12)
ai-app-1  |     at onErrorNT (node:internal/child_process:476:16)
ai-app-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
ai-app-1  |   errno: -2,
ai-app-1  |   code: 'ENOENT',
ai-app-1  |   syscall: 'spawn /usr/bin/mecab',
ai-app-1  |   path: '/usr/bin/mecab',
ai-app-1  |   spawnargs: [ '-d', '/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd/' ]
ai-app-1  | }
```

Dockerで `enable_mecab=0` にするなど、MeCabと `mecab-ipadic-neologd` がインストールされていない、かつ、 `keywordEnabled: true` な状態で起動すると、キーワードを覚える際に上記エラーで落ちます。
従って、 `keywordEnabled: true` な場合はbot起動前にMeCabと `mecab-ipadic-neologd` が入っているか確認し、入っていなかったら落ちるようにします。