### PR TITLE
fix: ログ出力に日付追加

### DIFF
--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -2,7 +2,7 @@ import * as chalk from 'chalk';
 
 export default function(msg: string) {
 	const now = new Date();
-	const date = `${zeroPad(now.getHours())}:${zeroPad(now.getMinutes())}:${zeroPad(now.getSeconds())}`;
+	const date = `${now.getFullYear()}-${zeroPad(now.getMonth() + 1)}-${zeroPad(now.getDate())} ${zeroPad(now.getHours())}:${zeroPad(now.getMinutes())}:${zeroPad(now.getSeconds())}`;
 	console.log(`${chalk.gray(date)} ${msg}`);
 }
 


### PR DESCRIPTION
日付があった方がログを追いやすいので、ログ出力に日付 ( `YYYY-MM-DD` ) を追加します。