### PR TITLE
fix: #135

### DIFF
--- a/src/serifs.ts
+++ b/src/serifs.ts
@@ -385,7 +385,8 @@ export default {
 		post: (server_name, num) => `${server_name}に${num}件の絵文字が追加されました！`,
 		emojiPost: emoji => `:${emoji}:\n(\`${emoji}\`) #AddCustomEmojis`,
 		postOnce: (server_name, num, text) => `${server_name}に${num}件の絵文字が追加されました！\n${text} #AddCustomEmojis`,
-		emojiOnce: emoji => `:${emoji}:(\`${emoji}\`)`
+		emojiOnce: emoji => `:${emoji}:(\`${emoji}\`)`,
+		nothing: '絵文字を確認しましたが、なにも追加されていないみたいです',
 	},
 
 	sleepReport: {


### PR DESCRIPTION
#135 を修正し、ついでにわかりづらい挙動を修正します

- read:admin:emoji権限がない場合その旨ポストするよう変更
- メンション起動の場合は、カスタム絵文字追加がなかったとき、なにも追加されてないことを返答するよう変更
  - 何もなかったのか、失敗したのかがわかりづらかったため