### PR TITLE
Node.js v22でのimport assertionの廃止に対応

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -16,7 +16,7 @@ import type { User } from '@/misskey/user.js';
 import Stream from '@/stream.js';
 import log from '@/utils/log.js';
 import { sleep } from './utils/sleep.js';
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 type MentionHook = (msg: Message) => Promise<boolean | HandlerResult>;
 type ContextHook = (key: any, msg: Message, data?: any) => Promise<void | boolean | HandlerResult>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,7 @@ type Config = {
 	memoryDir?: string;
 };
 
-import config from '../config.json' assert { type: 'json' };
+import config from '../config.json' with { type: 'json' };
 
 config.wsUrl = config.host.replace('http', 'ws');
 config.apiUrl = config.host + '/api';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import promiseRetry from 'promise-retry';
 import 藍 from './ai.js';
 import config from './config.js';
 import _log from './utils/log.js';
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 import CoreModule from './modules/core/index.js';
 import TalkModule from './modules/talk/index.js';


### PR DESCRIPTION
現在藍ちゃんをDockerで動かすと`node:lts`のNode.jsのバージョンがv22になっているため以下のエラーが出て起動に失敗します。

```
app-1  | > start
app-1  | > node ./built
app-1  | 
app-1  | file:///ai/built/index.js:8
app-1  | import pkg from '../package.json' assert { type: 'json' };
app-1  |                                   ^^^^^^
app-1  | 
app-1  | SyntaxError: Unexpected identifier 'assert'
app-1  |     at compileSourceTextModule (node:internal/modules/esm/utils:338:16)
app-1  |     at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
app-1  |     at #translate (node:internal/modules/esm/loader:437:12)
app-1  |     at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:484:27)
app-1  |     at async ModuleJob._link (node:internal/modules/esm/module_job:115:19)
app-1  | 
app-1  | Node.js v22.12.0
app-1 exited with code 0
```

これはNode.js v22においてimport assertionが廃止されたためです。
https://nodejs.org/docs/latest-v22.x/api/esm.html#import-attributes
この問題を回避するため`assert`を`with`に変更しています。 