### PR TITLE
aichatにGeminiを使用したときにうまく返答できないバグを修正

### DIFF
--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -127,7 +127,6 @@ export default class extends Module {
 		try {
 			res_data = await got.post(options,
 				{parseJson: (res: string) => JSON.parse(res)}).json();
-				{parseJson: res => JSON.parse(res)}).json();
 			this.log(JSON.stringify(res_data));
 			if (res_data.hasOwnProperty('candidates')) {
 				if (res_data.candidates.length > 0) {


### PR DESCRIPTION
aichatにGeminiを使用すると以下のエラーが出てうまく返答できなかったので修正しました

```
app-1  | 19:24:41 [AiOS]: [aichat]: Error By Call Gemini
app-1  | 19:24:41 [AiOS]: [aichat]: ReferenceError
app-1  | json is not defined
app-1  | ReferenceError: json is not defined
app-1  |     at default_1.genTextByGemini (file:///ai/built/modules/aichat/index.js:95:13)
app-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
app-1  |     at async default_1.handleAiChat (file:///ai/built/modules/aichat/index.js:366:24)
app-1  |     at async default_1.mentionHook (file:///ai/built/modules/aichat/index.js:221:24)
app-1  |     at async invokeMentionHooks (file:///ai/built/ai.js:149:23)
app-1  |     at async 藍.onReceiveMessage (file:///ai/built/ai.js:174:13)
app-1  | 19:24:41 [AiOS]: [aichat]: The result is invalid. It seems that tokens and other items need to be reviewed.
app-1  | 19:24:41 [AiOS]: >>> Sending reply to a2n15qwtago407yh
app-1  | 19:24:42 [AiOS]: API: notes/reactions/create
app-1  | 19:24:43 [AiOS]: API: notes/create
```