### PR TITLE
enhance:aichatの改善(画像以外に対応、複数ファイルに対応、時間と名前を渡すなど)

### DIFF
--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -382,6 +382,7 @@ export default class extends Module {
 			note.replyId == null &&
 			note.renoteId == null &&
 			note.cw == null &&
+			note.files.length == 0 &&
 			!note.user.isBot
 		);
 

--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -106,7 +106,18 @@ export default class extends Module {
 	private async genTextByGemini(aiChat: AiChat, files:base64File[]) {
 		this.log('Generate Text By Gemini...');
 		let parts: GeminiParts = [];
-		const systemInstruction: GeminiSystemInstruction = {role: 'system', parts: [{text: aiChat.prompt}]};
+		const now = new Date().toLocaleString('ja-JP', {
+			timeZone: 'Asia/Tokyo',
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
+		});
+		// 設定のプロンプトに加え、現在時刻を渡す
+		let systemInstructionText = aiChat.prompt + "。また、現在日時は" + now + "である(他の日時は無効とすること)。";
+		const systemInstruction: GeminiSystemInstruction = {role: 'system', parts: [{text: systemInstructionText}]};
 
 		parts = [{text: aiChat.question}];
 		// ファイルが存在する場合、画像を添付して問い合わせ

--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -113,11 +113,10 @@ export default class extends Module {
 			month: '2-digit',
 			day: '2-digit',
 			hour: '2-digit',
-			minute: '2-digit',
-			second: '2-digit'
+			minute: '2-digit'
 		});
 		// 設定のプロンプトに加え、現在時刻を渡す
-		let systemInstructionText = aiChat.prompt + "。また、現在日時は" + now + "である(他の日時は無効とすること)。";
+		let systemInstructionText = aiChat.prompt + "。また、現在日時は" + now + "であり、これは回答の参考にし、時刻を聞かれるまで時刻情報は提供しないこと(なお、他の日時は無効とすること)。";
 		// 名前を伝えておく
 		if (aiChat.friendName != undefined) {
 			systemInstructionText += "なお、会話相手の名前は" + aiChat.friendName + "とする。";

--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -288,7 +288,6 @@ export default class extends Module {
 				exist = this.aichatHist.findOne({
 					postId: message.id
 				});
-				// 見つかった場合はそれを利用
 				if (exist != null) return false;
 			}
 		}
@@ -309,6 +308,20 @@ export default class extends Module {
 			createdAt: Date.now(),// 適当なもの
 			type: type
 		};
+		// 引用している場合、情報を取得しhistoryとして与える
+		if (msg.quoteId) {
+			const quotedNote = await this.ai.api("notes/show", {
+				noteId: msg.quoteId,
+			});
+			current.history = [
+				{
+					role: "user",
+					content:
+						"ユーザーが与えた前情報である、引用された文章: " +
+						quotedNote.text,
+				},
+			];
+		}
 		// AIに問い合わせ
 		const result = await this.handleAiChat(current, msg);
 


### PR DESCRIPTION
以下の通り、aichatについて改善しています。

- 画像以外のファイルに対応
  - いままでは画像だけでしたが、画像以外(音声やテキストファイルなど)に対応しました
- 複数ファイルに対応
  - いままでは先頭のファイルだけみせていましたが、複数ファイルに対応しました
- 現在日時を渡す
  - LLMは現在時刻をしらないため変な応答をしがちなので日時を渡しました
- 対話相手の名前を渡す(名前の優先順: 藍ちゃんが認識している名前＞名前＞ユーザー名)
  - 藍ちゃんがもってる名前を使うようにしました
- ランダムトークの対象を変更
  - ファイルがあるノートは除外(勝手にLLM側に送るのはひどすぎたため)
- ノートが引用されている場合引用されているノートの文章を渡す