### PR TITLE
node-canvasを2.11.2から3.0.0に変更することでモジュールNotFoundを回避

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@types/twemoji-parser": "13.1.4",
 		"@types/uuid": "9.0.7",
 		"@types/ws": "8.5.10",
-		"canvas": "2.11.2",
+		"canvas": "3.0.0",
 		"chalk": "5.3.0",
 		"formdata-node": "6.0.3",
 		"got": "14.0.0",


### PR DESCRIPTION
nodeのバージョンのせいか、node-canvas側のせいかはよくわかってないですが、
現在エラーになっていたので動作するバージョンに変更しました。

- fix #161
  - upgrade canvas(2.11.2->3.0.0) 