### PR TITLE
fix: 「おはよう」など特定のワードを含むリプライにaichatが反応できない

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ promiseRetry(retry => {
 	// 藍起動
 	new 藍(account, [
 		new CoreModule(),
+		new AiChatModule(),
 		new EmojiModule(),
 		new EmojiReactModule(),
 		new FortuneModule(),
@@ -97,7 +98,6 @@ promiseRetry(retry => {
 		new PollModule(),
 		new ReminderModule(),
 		new CheckCustomEmojisModule(),
-		new AiChatModule(),
 	]);
 }).catch(e => {
 	log(chalk.red('Failed to fetch the account'));


### PR DESCRIPTION
モジュールの初期化順(mentionHookのインストール順)を変更することで、aichatの優先度が高くなるようにした