### PR TITLE
Update default Gemini Flash model to 2.5

### DIFF
--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -86,7 +86,7 @@ const GEMINI_FLASH = 'gemini-flash';
 const TYPE_PLAMO = 'plamo';
 const GROUNDING_TARGET = 'ggg';
 
-const GEMINI_20_FLASH_API = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent';
+const GEMINI_20_FLASH_API = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
 // const GEMINI_15_FLASH_API = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 const GEMINI_15_PRO_API = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent';
 const PLAMO_API = 'https://platform.preferredai.jp/api/completion/v1/chat/completions';


### PR DESCRIPTION
Changed the default Gemini Flash API endpoint from gemini-2.0-flash-exp to gemini-2.5-flash. This ensures compatibility with the latest available Gemini Flash model.