### PR TITLE
Add geminiModel option to Config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ type Config = {
 	checkEmojisEnabled?: boolean;
 	checkEmojisAtOnce?: boolean;
 	geminiProApiKey?: string;
+	geminiModel?: string; // <-- new
 	pLaMoApiKey?: string;
 	prompt?: string;
 	aichatRandomTalkEnabled?: boolean;


### PR DESCRIPTION
- Added optional field geminiModel?: string to Config type
- Allows selecting default Gemini model (e.g., gemini-2.5-flash, gemini-2.5-pro)
- Used by aichat module for AI chat integration